### PR TITLE
SMT: adding constructs

### DIFF
--- a/pkg/err/errors.go
+++ b/pkg/err/errors.go
@@ -23,6 +23,7 @@ var (
 	ErrSchemaVarTypeNotFound        = errors.New("type for schema variable not found")
 	ErrEmptyReferenceConv           = errors.New("Cannot convert empty reference")
 	ErrInvalidEmptyTerm             = errors.New("invalid or empty expression terms")
+	ErrTypeNotFound                 = errors.New("type not found")
 )
 
 // ErrSmtConstraints returns an error for SMT constraint generation failure.

--- a/pkg/smt/exprs.go
+++ b/pkg/smt/exprs.go
@@ -193,7 +193,7 @@ func (t *Translator) refToSmt(ref ast.Ref) (string, error) {
 		}
 		tp, ok := t.TypeInfo.Types[baseVar]
 		if !ok {
-			return "", verr.ErrSchemaVarTypeNotFound
+			return "", verr.ErrTypeNotFound
 		}
 		smt, err := getSmtRef(baseVar, path, &tp)
 		if err != nil {
@@ -221,7 +221,7 @@ func (t *Translator) explicitArrayToSmt(arr *ast.Array) (string, error) {
 	termStr := arr.String()
 	tp, ok := t.TypeInfo.Types[termStr]
 	if !ok {
-		return "", verr.ErrSchemaVarTypeNotFound
+		return "", verr.ErrTypeNotFound
 	}
 	varDecl, err := getVarDeclaration(varName, &tp)
 	if err != nil {
@@ -265,14 +265,14 @@ func (t *Translator) declareUnintFunc(name string, terms []*ast.Term) error {
 	for i := 1; i < len(terms); i++ {
 		tp, ok := t.TypeInfo.Types[terms[i].String()]
 		if !ok {
-			return fmt.Errorf("type information not found for term: %s", terms[i].String())
+			return verr.ErrTypeNotFound
 		}
 		pars[i-1] = getSmtType(&tp)
 	}
 	// gather return type
 	rtype, ok := t.TypeInfo.Types[terms[0].String()]
 	if !ok {
-		return fmt.Errorf("type information not found for term: %s", terms[0].String())
+		return verr.ErrTypeNotFound
 	}
 
 	decls := fmt.Sprintf("(declare-fun %s (%s) %s)", name, strings.Join(pars, " "), getSmtType(&rtype))
@@ -294,7 +294,7 @@ func (t *Translator) handleConstObject(obj ast.Object) (string, error) {
 	varName := t.getFreshVariable("const_obj")
 	tp, ok := t.TypeInfo.Types[obj.String()]
 	if !ok {
-		return "", fmt.Errorf("type information not found for object: %s", obj.String())
+		return "", verr.ErrTypeNotFound
 	}
 
 	decl, err := getVarDeclaration(varName, &tp)

--- a/pkg/smt/exprs_test.go
+++ b/pkg/smt/exprs_test.go
@@ -20,6 +20,17 @@ func newDummyTranslator() *Translator {
 	}
 	return &Translator{
 		TypeInfo: ta,
+		VarMap:   make(map[string]string),
+	}
+}
+
+func newTestTranslatorWithTypes(typeMap map[string]types.RegoTypeDef) *Translator {
+	return &Translator{
+		TypeInfo: &types.TypeAnalyzer{
+			Types: typeMap,
+			Refs:  map[string]ast.Value{},
+		},
+		VarMap: make(map[string]string),
 	}
 }
 
@@ -177,7 +188,7 @@ func TestExprToSmt_BasicOps(t *testing.T) {
 			ast.NewTerm(ast.Number("2")),
 		},
 	}
-	got, err := tr.exprToSmt(plusExpr)
+	got, err := tr.exprToSmt(&plusExpr)
 	if err != nil {
 		t.Errorf("exprToSmt() error = %v", err)
 	}
@@ -187,7 +198,7 @@ func TestExprToSmt_BasicOps(t *testing.T) {
 	}
 
 	// expr: eq("foo", "foo") => (= "foo" "foo")
-	eqExpr := ast.Expr{
+	eqExpr := &ast.Expr{
 		Terms: []*ast.Term{
 			ast.NewTerm(ast.String("eq")),
 			ast.NewTerm(ast.String("foo")),
@@ -276,7 +287,7 @@ func TestExprToSmt_Advanced(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := tr.exprToSmt(tt.expr)
+			got, err := tr.exprToSmt(&tt.expr)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("exprToSmt() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -284,5 +295,171 @@ func TestExprToSmt_Advanced(t *testing.T) {
 				t.Errorf("exprToSmt() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestExplicitArrayToSmt_Success(t *testing.T) {
+	tr := newDummyTranslator()
+	// Add type info for the array string representation
+	arr := ast.NewArray(ast.IntNumberTerm(1), ast.IntNumberTerm(2), ast.IntNumberTerm(3))
+	arrStr := arr.String()
+	tr.TypeInfo.Types[arrStr] = types.NewArrayType(types.NewAtomicType(types.AtomicInt))
+	got, err := tr.explicitArrayToSmt(arr)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if got == "" {
+		t.Errorf("expected non-empty SMT var name, got empty string")
+	}
+	// More sophisticated checks: variable name format and side effects
+	if !strings.HasPrefix(got, "const_arr") {
+		t.Errorf("expected SMT var name to start with 'const_arr_', got %q", got)
+	}
+	// Check that a declaration and assertion were added
+	if len(tr.smtDecls) == 0 {
+		t.Errorf("expected at least one SMT declaration, got none")
+	}
+	if len(tr.smtAsserts) == 0 {
+		t.Errorf("expected at least one SMT assertion, got none")
+	}
+}
+
+func TestExplicitArrayToSmt_TypeNotFound(t *testing.T) {
+	tr := newDummyTranslator()
+	arr := ast.NewArray(ast.IntNumberTerm(1), ast.IntNumberTerm(2))
+	_, err := tr.explicitArrayToSmt(arr)
+	if err == nil {
+		t.Fatalf("expected error for missing type info, got nil")
+	}
+}
+
+func TestExprToSmt_AllCases(t *testing.T) {
+	t.Parallel()
+	t.Run("Builtins", func(t *testing.T) {
+		t.Parallel()
+		typeMap := map[string]types.RegoTypeDef{
+			"plus": types.NewAtomicType(types.AtomicInt),
+			"1":    types.NewAtomicType(types.AtomicInt),
+			"2":    types.NewAtomicType(types.AtomicInt),
+		}
+		tr := newTestTranslatorWithTypes(typeMap)
+		expr := ast.MustParseExpr("plus(1,2)")
+		smt, err := tr.exprToSmt(expr)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		expected := "(+ 1 2)"
+		if smt != expected {
+			t.Errorf("expected %q, got %q", expected, smt)
+		}
+	})
+
+	t.Run("Neq", func(t *testing.T) {
+		t.Parallel()
+		typeMap := map[string]types.RegoTypeDef{
+			"neq": types.NewAtomicType(types.AtomicBoolean),
+			"1":   types.NewAtomicType(types.AtomicInt),
+			"2":   types.NewAtomicType(types.AtomicInt),
+		}
+		tr := newTestTranslatorWithTypes(typeMap)
+		expr := ast.MustParseExpr("neq(1,2)")
+		smt, err := tr.exprToSmt(expr)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		expected := "(not (= 1 2))"
+		if smt != expected {
+			t.Errorf("expected %q, got %q", expected, smt)
+		}
+	})
+
+	t.Run("Uninterpreted", func(t *testing.T) {
+		t.Parallel()
+		typeMap := map[string]types.RegoTypeDef{
+			"foo": types.NewAtomicType(types.AtomicString),
+			"1":   types.NewAtomicType(types.AtomicInt),
+			"2":   types.NewAtomicType(types.AtomicInt),
+		}
+		tr := newTestTranslatorWithTypes(typeMap)
+		expr := ast.MustParseExpr("foo(1,2)")
+		smt, err := tr.exprToSmt(expr)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// The function name will be a fresh variable, so just check the format
+		if len(tr.smtDecls) == 0 {
+			t.Errorf("expected a function declaration in smtDecls")
+		}
+		decl := tr.smtDecls[len(tr.smtDecls)-1]
+		if decl == "" || decl[:13] != "(declare-fun " {
+			t.Errorf("expected function declaration, got %q", decl)
+		}
+		if smt[:1] != "(" || smt[len(smt)-1:] != ")" {
+			t.Errorf("expected function application format, got %q", smt)
+		}
+	})
+
+	t.Run("TypeError", func(t *testing.T) {
+		t.Parallel()
+		typeMap := map[string]types.RegoTypeDef{
+			"foo": types.NewAtomicType(types.AtomicFunction),
+			// missing type for "1"
+		}
+		tr := newTestTranslatorWithTypes(typeMap)
+		expr := ast.MustParseExpr("foo(1)")
+		_, err := tr.exprToSmt(expr)
+		if err == nil {
+			t.Errorf("expected error for missing type, got nil")
+		}
+	})
+}
+
+func TestExplicitArrayToSmt_CompareFullSmtLib(t *testing.T) {
+	arrTerm := ast.MustParseTerm(`[1, 2, 3]`)
+	arr, ok := arrTerm.Value.(*ast.Array)
+	if !ok {
+		t.Fatalf("expected ast.Array, got %T", arrTerm.Value)
+	}
+
+	typeMap := map[string]types.RegoTypeDef{
+		arr.String(): types.NewArrayType(types.NewAtomicType(types.AtomicInt)),
+	}
+	tr := newTestTranslatorWithTypes(typeMap)
+
+	varName, err := tr.explicitArrayToSmt(arr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if varName == "" {
+		t.Fatalf("expected non-empty SMT var name")
+	}
+
+	var sb strings.Builder
+	for _, decl := range tr.smtDecls {
+		sb.WriteString(decl)
+		sb.WriteString("\n")
+	}
+	for _, asrt := range tr.smtAsserts {
+		sb.WriteString(asrt)
+		sb.WriteString("\n")
+	}
+	smtlib := sb.String()
+
+	expectedDeclPrefix := "(declare-fun " + varName + " () OTypeD1)"
+	expectedElem0 := "(assert (= (select (arr " + varName + ") 0) 1))"
+	expectedElem1 := "(assert (= (select (arr " + varName + ") 1) 2))"
+	expectedElem2 := "(assert (= (select (arr " + varName + ") 2) 3))"
+
+	if !strings.Contains(smtlib, expectedDeclPrefix) {
+		t.Errorf("expected SMT-LIB to contain declaration: %q\nGot:\n%s", expectedDeclPrefix, smtlib)
+	}
+	if !strings.Contains(smtlib, expectedElem0) {
+		t.Errorf("expected SMT-LIB to contain: %q\nGot:\n%s", expectedElem0, smtlib)
+	}
+	if !strings.Contains(smtlib, expectedElem1) {
+		t.Errorf("expected SMT-LIB to contain: %q\nGot:\n%s", expectedElem1, smtlib)
+	}
+	if !strings.Contains(smtlib, expectedElem2) {
+		t.Errorf("expected SMT-LIB to contain: %q\nGot:\n%s", expectedElem2, smtlib)
 	}
 }

--- a/pkg/smt/rules.go
+++ b/pkg/smt/rules.go
@@ -78,7 +78,7 @@ func (t *Translator) RuleToSmt(rule *ast.Rule) error {
 	// Convert all body expressions to SMT
 	bodySmts := make([]string, 0, len(rule.Body))
 	for _, expr := range rule.Body {
-		smtStr, err := t.exprToSmt(*expr)
+		smtStr, err := t.exprToSmt(expr)
 		if err != nil {
 			return fmt.Errorf("failed to convert rule body expr: %w", err)
 		}

--- a/pkg/smt/rules.go
+++ b/pkg/smt/rules.go
@@ -95,6 +95,6 @@ func (t *Translator) RuleToSmt(rule *ast.Rule) error {
 	}
 
 	assertion := fmt.Sprintf("(assert (= %s %s))", smtHead, bodySmt)
-	t.smtLines = append(t.smtLines, assertion)
+	t.smtAsserts = append(t.smtAsserts, assertion)
 	return nil
 }

--- a/pkg/smt/rules_test.go
+++ b/pkg/smt/rules_test.go
@@ -26,16 +26,17 @@ func TestRuleToSmt_Basic(t *testing.T) {
 		},
 		Refs: map[string]ast.Value{},
 	}
-	tr := &Translator{TypeInfo: ta, smtLines: make([]string, 0, 8)}
+	tr := NewTranslator(ta, mod)
 	rule := mod.Rules[0]
 	err = tr.RuleToSmt(rule)
 	if err != nil {
 		t.Fatalf("RuleToSmt error: %v", err)
 	}
-	if len(tr.smtLines) == 0 {
+	lines := tr.SmtLines()
+	if len(lines) == 0 {
 		t.Fatalf("No SMT lines generated")
 	}
-	got := tr.smtLines[len(tr.smtLines)-1]
+	got := lines[len(lines)-1]
 	if got == "" || got[:7] != "(assert" {
 		t.Errorf("Expected SMT assertion, got: %q", got)
 	}
@@ -55,13 +56,17 @@ func TestRuleToSmt_NoBody(t *testing.T) {
 		},
 		Refs: map[string]ast.Value{},
 	}
-	tr := &Translator{TypeInfo: ta, smtLines: make([]string, 0, 8)}
+	tr := NewTranslator(ta, mod)
 	rule := mod.Rules[0]
 	err = tr.RuleToSmt(rule)
 	if err != nil {
 		t.Fatalf("RuleToSmt error: %v", err)
 	}
-	got := tr.smtLines[len(tr.smtLines)-1]
+	lines := tr.SmtLines()
+	if len(lines) == 0 {
+		t.Fatalf("No SMT lines generated")
+	}
+	got := lines[len(lines)-1]
 	if got == "" || got[:7] != "(assert" {
 		t.Errorf("Expected SMT assertion, got: %q", got)
 	}

--- a/pkg/smt/translator.go
+++ b/pkg/smt/translator.go
@@ -1,6 +1,8 @@
 package smt
 
 import (
+	"fmt"
+
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/vhavlena/verirego/pkg/types"
 )
@@ -129,4 +131,36 @@ func (t *Translator) TranslateModuleToSmt() error {
 		}
 	}
 	return nil
+}
+
+// getFreshVariable returns a fresh temporary variable name that does not clash with any variable in TypeInfo or any value in VarMap.
+//
+// Args:
+//
+//	prefix (string): The prefix to use for the generated variable name.
+//
+// Returns:
+//
+//	string: A fresh variable name with the given prefix, guaranteed not to conflict with existing variables.
+func (t *Translator) getFreshVariable(prefix string) string {
+	// Collect all used names: keys in TypeInfo.Types and values in VarMap
+	used := make(map[string]struct{})
+	if t.TypeInfo != nil {
+		for name := range t.TypeInfo.Types {
+			used[name] = struct{}{}
+		}
+	}
+	for _, v := range t.VarMap {
+		used[v] = struct{}{}
+	}
+	// Try to find a fresh variable name
+	for i := 0; ; i++ {
+		varName := prefix
+		if i > 0 {
+			varName = prefix + fmt.Sprintf("_%d", i)
+		}
+		if _, exists := used[varName]; !exists {
+			return varName
+		}
+	}
 }

--- a/pkg/smt/translator_test.go
+++ b/pkg/smt/translator_test.go
@@ -101,15 +101,16 @@ func TestTranslateModuleToSmt_Basic(t *testing.T) {
 		},
 		Refs: map[string]ast.Value{},
 	}
-	tr := &Translator{TypeInfo: ta, smtLines: make([]string, 0, 8), mod: mod}
+	tr := NewTranslator(ta, mod)
 	err = tr.TranslateModuleToSmt()
 	if err != nil {
 		t.Fatalf("TranslateModuleToSmt error: %v", err)
 	}
-	if len(tr.smtLines) != 2 {
-		t.Errorf("Expected 2 SMT assertions, got %d", len(tr.smtLines))
+	smtLines := tr.SmtLines()
+	if len(smtLines) != 2 {
+		t.Errorf("Expected 2 SMT assertions, got %d", len(smtLines))
 	}
-	for i, line := range tr.smtLines {
+	for i, line := range smtLines {
 		if line == "" || line[:7] != "(assert" {
 			t.Errorf("SMT line %d not an assertion: %q", i, line)
 		}

--- a/pkg/smt/type_defs.go
+++ b/pkg/smt/type_defs.go
@@ -129,7 +129,20 @@ func (t *Translator) getDatatypesDeclaration() []string {
 //	string: The SMT-LIB variable declaration string.
 //	error: An error if the declaration could not be generated.
 func getVarDeclaration(name string, tp *types.RegoTypeDef) (string, error) {
-	return fmt.Sprintf("(declare-fun %s () OTypeD%d)", name, tp.TypeDepth()), nil
+	return fmt.Sprintf("(declare-fun %s () %s)", name, getSmtType(tp)), nil
+}
+
+// getSmtType returns the SMT-LIB sort name for a given Rego type definition based on its type depth.
+//
+// Parameters:
+//
+//	ttp *types.RegoTypeDef: The Rego type definition.
+//
+// Returns:
+//
+//	string: The SMT-LIB sort name corresponding to the type depth.
+func getSmtType(tp *types.RegoTypeDef) string {
+	return fmt.Sprintf("OTypeD%d", tp.TypeDepth())
 }
 
 // getSortDefinitions returns SMT-LIB sort definitions up to the given maximum depth.

--- a/pkg/smt/type_defs.go
+++ b/pkg/smt/type_defs.go
@@ -34,7 +34,7 @@ func RandString(n int) string {
 //	error: An error if any variable declaration or constraint generation fails.
 func (t *Translator) GenerateTypeDefs(usedVars map[string]any) error {
 	datatypes := t.getDatatypesDeclaration()
-	t.smtLines = append(t.smtLines, datatypes...)
+	t.smtTypeDecls = append(t.smtTypeDecls, datatypes...)
 
 	maxDepth := 0
 	vars := make([]string, 0, len(t.TypeInfo.Types))
@@ -46,7 +46,7 @@ func (t *Translator) GenerateTypeDefs(usedVars map[string]any) error {
 		maxDepth = max(maxDepth, tp.TypeDepth())
 	}
 	sortDefs := t.getSortDefinitions(maxDepth)
-	t.smtLines = append(t.smtLines, sortDefs...)
+	t.smtTypeDecls = append(t.smtTypeDecls, sortDefs...)
 
 	for _, name := range vars {
 		tp := t.TypeInfo.Types[name]
@@ -54,7 +54,7 @@ func (t *Translator) GenerateTypeDefs(usedVars map[string]any) error {
 		if er != nil {
 			return er
 		}
-		t.smtLines = append(t.smtLines, smtVar)
+		t.smtDecls = append(t.smtDecls, smtVar)
 	}
 
 	for _, name := range vars {
@@ -63,7 +63,7 @@ func (t *Translator) GenerateTypeDefs(usedVars map[string]any) error {
 		if er != nil {
 			return er
 		}
-		t.smtLines = append(t.smtLines, smtConstr)
+		t.smtAsserts = append(t.smtAsserts, smtConstr)
 	}
 
 	return nil

--- a/pkg/types/type_analysis.go
+++ b/pkg/types/type_analysis.go
@@ -171,6 +171,7 @@ func (ta *TypeAnalyzer) InferExprType(expr *ast.Expr) RegoTypeDef {
 			for i := 1; i < len(terms); i++ {
 				ta.InferTermType(terms[i], &funcParams[i-1])
 			}
+			ta.setType(terms[0].Value, funcType)
 			return funcType
 		}
 	}
@@ -451,8 +452,11 @@ func funcParamsType(name string, params int) (RegoTypeDef, []RegoTypeDef) {
 		}
 		return NewAtomicType(AtomicString), pars
 	case name == "sprintf":
+		// format string
+		pars[0] = NewAtomicType(AtomicString)
+		// last parameter is a result
 		pars[len(pars)-1] = NewAtomicType(AtomicString)
-		return NewAtomicType(AtomicString), pars
+		return NewAtomicType(AtomicBoolean), pars
 
 	case isNumericFunction(name):
 		for i := 0; i < params; i++ {


### PR DESCRIPTION
This pull request introduces significant enhancements and refactoring to the SMT-LIB translation logic in the `pkg/smt` package. The changes include improvements to type handling, support for complex Rego constructs like arrays and objects, and updates to tests to validate the new functionality. Below is a summary of the most important changes:

### Enhancements to SMT-LIB Translation

* Updated the `exprToSmt` method to accept a pointer to `ast.Expr` and modified its logic to delegate array and object handling to new helper methods.
* Added new methods `explicitArrayToSmt` and `handleConstObject` to convert Rego arrays and objects into SMT-LIB variables, including their declarations and assertions.
* Enhanced the `regoFuncToSmt` method to support uninterpreted functions by declaring them dynamically based on type information.
### Refactoring and Code Simplification

* Refactored `regoFuncToSmt` to be a method of the `Translator` struct, enabling access to `TypeInfo` for type inference.
* Replaced the `smtLines` field in `Translator` with `smtDecls` and `smtAsserts` for better separation of SMT-LIB declarations and assertions.

### Test Coverage Improvements

* Added new test cases for `explicitArrayToSmt`, `handleConstObject`, and complex scenarios in `exprToSmt`, including built-in functions, uninterpreted functions, and type errors.
* Refactored existing tests to align with the updated `Translator` structure and methods.
### Minor Changes

* Updated import statements to include `fmt` for error handling in new methods.
* Adjusted test utilities to include a new helper function `newTestTranslatorWithTypes` for creating `Translator` instances with predefined type mappings .

These changes collectively improve the flexibility, correctness, and maintainability of the SMT-LIB translation logic while ensuring robust test coverage for the new and updated functionality.